### PR TITLE
Pg/gcc fix

### DIFF
--- a/stellar-core-postgres/rpm/stellar-core-postgres.spec
+++ b/stellar-core-postgres/rpm/stellar-core-postgres.spec
@@ -1,14 +1,14 @@
 %global debug_package %{nil}
 
 Name: stellar-core-postgres
-Version: 0.0.12
+Version: 19.2.0
 Release: 1%{?dist}
 Summary: Postgresql configuration for the Stellar Core
 License: Apache 2.0
 Source0: {{{ git_dir_pack }}}
 
 BuildRequires: systemd-rpm-macros
-Requires: stellar-core
+Requires: stellar-core == %{version}
 Requires: postgresql-server
 
 %description

--- a/stellar-core/rpm/stellar-core.spec
+++ b/stellar-core/rpm/stellar-core.spec
@@ -3,7 +3,7 @@
 
 Name: stellar-core
 Version: 19.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Stellar is a decentralized, federated peer-to-peer network
 
 License: Apache 2.0
@@ -22,13 +22,13 @@ Source108: https://api.github.com/repos/xdrpp/xdrpp/tarball/9fd7ca222bb26337e144
 
 # END: submodule sources
 %if 0%{?rhel} && 0%{?rhel} == 7
-BuildRequires: llvm-toolset-7.0-clang
-BuildRequires: devtoolset-8-gcc-c++
-BuildRequires: rh-postgresql12-postgresql-devel, rh-postgresql12-postgresql-server
+BuildRequires: devtoolset-10-gcc-c++
+BuildRequires: rh-postgresql13-postgresql-devel, rh-postgresql13-postgresql-server
 %else
 BuildRequires: clang >= 10
 BuildRequires: gcc-c++ >= 8
-BuildRequires: postgresql-devel, postgresql-server
+BuildRequires: postgresql-devel >= 13
+BuildRequires: postgresql-server >= 13
 %endif
 
 Requires: user(stellar)
@@ -75,9 +75,8 @@ tar -zxf  %{SOURCE108} --strip-components 1 -C lib/xdrpp/
 %build
 %if 0%{?rhel} && 0%{?rhel} == 7
     LDFLAGS=-Wl,-rpath,%{_datadir}/%{system_name}/lib/
-    source /opt/rh/rh-postgresql12/enable
-    source /opt/rh/devtoolset-8/enable
-    source /opt/rh/llvm-toolset-7.0/enable
+    source /opt/rh/rh-postgresql13/enable
+    source /opt/rh/devtoolset-10/enable
 %endif
 %configure
 %make_build
@@ -94,12 +93,14 @@ tar -zxf  %{SOURCE108} --strip-components 1 -C lib/xdrpp/
 %{__install} -d %{buildroot}%{_sysconfdir}/stellar
 
 %if 0%{?rhel} && 0%{?rhel} == 7
-    %{__install} -D /opt/rh/rh-postgresql12/root/usr/lib64/libpq.so.rh-postgresql12-5 %{buildroot}%{_datadir}/%{system_name}/lib/libpq.so.rh-postgresql12-5
+    %{__install} -D /opt/rh/rh-postgresql13/root/usr/lib64/libpq.so.rh-postgresql13-5 %{buildroot}%{_datadir}/%{system_name}/lib/libpq.so.rh-postgresql13-5
 %endif
 
 %check
 %if 0%{?rhel} && 0%{?rhel} == 7
-source /opt/rh/llvm-toolset-7.0/enable
+# ./xdrc/xdrc -hh -o tests/xdrtest.hh tests/xdrtest.x
+# g++: error: unrecognized command line option '-std=c++17'
+source /opt/rh/devtoolset-10/enable
 %endif
 
 make check
@@ -124,10 +125,14 @@ make check
 %dir %attr(0755, stellar, stellar) /var/log/stellar
 %dir %attr(0755, stellar, stellar) /var/lib/stellar/core
 %if 0%{?rhel} && 0%{?rhel} == 7
-    %{_datadir}/%{system_name}/lib/libpq.so.rh-postgresql12-5
+    %{_datadir}/%{system_name}/lib/libpq.so.rh-postgresql13-5
 %endif
 
 %changelog
+* Sun Jul 31 2022 Anatolii Vorona <vorona.tolik@gmail.com>
+- update v19.2.0
+- postgresql libs should be >= 13
+
 * Mon Jun 06 2022 Anatolii Vorona <vorona.tolik@gmail.com>
 - update v19.1.0
 


### PR DESCRIPTION
```
rh-postgresql12-postgresql-devel  x86_64 12.9-1.el7             http_mirror_centos_org_centos_7_sclo_x86_64_rh

clang++ -std=c++17 -DHAVE_CONFIG_H -I. -I..  -isystem ".." -I"../src" -I"../src" -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include/sodium -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/xdrpp -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/xdrpp -isystem ../lib/libmedida/src -isystem ../lib/soci/src/core -isystem ../lib/sqlite -DSQLITE_CORE -DSQLITE_OMIT_LOAD_EXTENSION=1 -DASIO_SEPARATE_COMPILATION=1 -DASIO_STANDALONE -isystem ../lib/asio/asio/include  -isystem "../lib" -isystem "../lib/autocheck/include" -isystem "../lib/cereal/include" -isystem "../lib/util" -isystem "../lib/fmt/include" -isystem "../lib/soci/src/core" -isystem "../lib/tracy" -isystem "../lib/spdlog/include" -isystem "../rust/src" -DUSE_POSTGRES=1 -I/opt/rh/rh-postgresql12/root/usr/include    -I"../src/protocol-curr"  -DBUILD_TESTS=1 -DUSE_SPDLOG    -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic -pthread -DFMT_HEADER_ONLY=1 -Wno-unused-command-line-argument -Qunused-arguments -Wno-unused-local-typedef -Wno-unknown-warning-option -Werror=unused-result -c -o util/xdrquery/XDRQueryScanner.o util/xdrquery/XDRQueryScanner.cpp
util/xdrquery/XDRQueryScanner.cpp:668:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register yy_state_type yy_current_state;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:669:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp, *yy_bp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:669:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp, *yy_bp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:670:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int yy_act;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:719:4: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
                        register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
                        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:994:6: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:995:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *source = (yytext_ptr);
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:996:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int number_to_move, i;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:996:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int number_to_move, i;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1128:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register yy_state_type yy_current_state;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1129:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1135:3: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
                register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
                ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1160:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int yy_is_jam;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1161:6: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp = (yy_c_buf_p);
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1163:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register YY_CHAR yy_c = 1;
        ^~~~~~~~~
15 errors generated.

upgrade postgresql requirements

postgresql                       x86_64  10.19-1.module_el8.6.0+1047+4202cf9a  appstream                                                                                                             1.5
Computers / CPU cores / Max jobs to run
1:local / 2 / 1

Computer:jobs running/jobs completed/%of started jobs/Average seconds to complete
local:1/0/100%/0.0s 1	Creating temporary PostgreSQL database cluster in /tmp/pgtmp.AAoCNQbY with --locale=en_US@ampm.UTF-8
local:1/0/100%/0.0s 1	Could not enable PostgreSQL
1	initdb: invalid locale name "en_US@ampm.UTF-8"
1	pg_ctl: database system initialization failed
local:1/0/100%/0.0s 1	pg_ctl: directory "/tmp/pgtmp.AAoCNQbY" is not a database cluster directory
local:1/0/100%/0.0s parallel: This job failed:
runpart 1 'Create account above minimum balance' 'change trust' 'BitSet symmetric difference' clawback 'reject peers with the same nodeid'
FAIL: test/selftest-pg
PASS: test/check-nondet
===================
1 of 2 tests failed
```

```
rh-postgresql12-postgresql-devel  x86_64 12.9-1.el7             http_mirror_centos_org_centos_7_sclo_x86_64_rh

clang++ -std=c++17 -DHAVE_CONFIG_H -I. -I..  -isystem ".." -I"../src" -I"../src" -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include/sodium -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/xdrpp -isystem /builddir/build/BUILD/stellar-core-19.2.0/lib/xdrpp -isystem ../lib/libmedida/src -isystem ../lib/soci/src/core -isystem ../lib/sqlite -DSQLITE_CORE -DSQLITE_OMIT_LOAD_EXTENSION=1 -DASIO_SEPARATE_COMPILATION=1 -DASIO_STANDALONE -isystem ../lib/asio/asio/include  -isystem "../lib" -isystem "../lib/autocheck/include" -isystem "../lib/cereal/include" -isystem "../lib/util" -isystem "../lib/fmt/include" -isystem "../lib/soci/src/core" -isystem "../lib/tracy" -isystem "../lib/spdlog/include" -isystem "../rust/src" -DUSE_POSTGRES=1 -I/opt/rh/rh-postgresql12/root/usr/include    -I"../src/protocol-curr"  -DBUILD_TESTS=1 -DUSE_SPDLOG    -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic -pthread -DFMT_HEADER_ONLY=1 -Wno-unused-command-line-argument -Qunused-arguments -Wno-unused-local-typedef -Wno-unknown-warning-option -Werror=unused-result -c -o util/xdrquery/XDRQueryScanner.o util/xdrquery/XDRQueryScanner.cpp
util/xdrquery/XDRQueryScanner.cpp:668:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register yy_state_type yy_current_state;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:669:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp, *yy_bp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:669:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp, *yy_bp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:670:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int yy_act;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:719:4: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
                        register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
                        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:994:6: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:995:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *source = (yytext_ptr);
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:996:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int number_to_move, i;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:996:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int number_to_move, i;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1128:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register yy_state_type yy_current_state;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1129:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1135:3: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
                register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
                ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1160:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int yy_is_jam;
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1161:6: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register char *yy_cp = (yy_c_buf_p);
        ^~~~~~~~~
util/xdrquery/XDRQueryScanner.cpp:1163:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register YY_CHAR yy_c = 1;
        ^~~~~~~~~
15 errors generated.
```